### PR TITLE
Add alert deduping, ticker resolver, and seen store

### DIFF
--- a/src/catalyst_bot/alert_guard.py
+++ b/src/catalyst_bot/alert_guard.py
@@ -1,0 +1,106 @@
+"""
+Alert Guard helpers
+
+- build_alert_id(payload): create a stable ID for dedupe/persistence when upstream
+  didn't provide one. Prefers explicit 'id' in payload; otherwise hashes a canonical
+  URL + normalized title (UTM scrubbed).
+
+This is used by sitecustomize.py to suppress re-alerts via SeenStore.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+
+def _clean_query(query: str) -> str:
+    """Remove tracking params like utm_*, gclid, fbclid; preserve order for stability."""
+    if not query:
+        return ""
+    pairs = [
+        (k, v)
+        for k, v in parse_qsl(query, keep_blank_values=True)
+        if not _is_tracking(k)
+    ]
+    if not pairs:
+        return ""
+    return urlencode(pairs)
+
+
+def _is_tracking(k: str) -> bool:
+    k = k.lower()
+    if k.startswith("utm_"):
+        return True
+    if k in {"gclid", "fbclid", "mc_cid", "mc_eid"}:
+        return True
+    return False
+
+
+def canonicalize_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    try:
+        p = urlparse(url)
+        host = (p.netloc or "").lower()
+        path = p.path or "/"
+        path = path if path.startswith("/") else "/" + path
+        # strip trailing slash except root
+        if len(path) > 1 and path.endswith("/"):
+            path = path[:-1]
+        query = _clean_query(p.query)
+        return urlunparse((p.scheme.lower(), host, path, "", query, ""))
+    except Exception:
+        return url
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_title(title: Optional[str]) -> str:
+    if not title:
+        return ""
+    t = title.strip()
+    t = _WHITESPACE_RE.sub(" ", t)
+    return t
+
+
+def build_alert_id(payload: Dict[str, Any]) -> Optional[str]:
+    """
+    Precedence:
+      1) payload.get('id') if it's a non-empty str
+      2) hash(canonical_url + "||" + normalized_title)
+      3) None if insufficient fields
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    # 1) explicit id
+    v = payload.get("id")
+    if isinstance(v, str) and v.strip():
+        return v.strip()
+
+    # 2) derive from link + title variants
+    candidates = [
+        payload.get("canonical_link"),
+        payload.get("url"),
+        payload.get("link"),
+    ]
+    url = next((u for u in candidates if isinstance(u, str) and u.strip()), None)
+    title = payload.get("title") if isinstance(payload.get("title"), str) else None
+
+    if not url and not title:
+        return None
+
+    can_url = canonicalize_url(url) if url else ""
+    norm_title = normalize_title(title) if title else ""
+    if not can_url and not norm_title:
+        return None
+
+    raw = f"{can_url}||{norm_title}"
+    h = hashlib.sha1(
+        raw.encode("utf-8")
+    ).hexdigest()  # stable, short enough for SQLite PK
+    return f"aid:{h}"

--- a/src/catalyst_bot/alerts_rate_limit.py
+++ b/src/catalyst_bot/alerts_rate_limit.py
@@ -1,0 +1,97 @@
+"""
+Alerts Rate Limiter (opt-in)
+
+Purpose
+-------
+Prevent Discord bursts by limiting posts per key (usually per ticker) within a
+time window. The hook in sitecustomize wraps alerts.post_discord_json when
+HOOK_ALERTS_RATE_LIMIT=true.
+
+Config (env)
+------------
+- ALERTS_RATE_WINDOW_SECS (default 60)
+- ALERTS_RATE_MAX         (default 4)
+
+Public helpers
+--------------
+- limiter_key_from_payload(payload: dict) -> str
+- limiter_allow(key: str) -> bool
+
+You can also probe the limiter directly via `_RL.allow("KEY")` in ad-hoc tests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import deque
+from typing import Deque, Dict
+
+try:
+    from catalyst_bot.logging_utils import get_logger  # type: ignore
+except Exception:  # pragma: no cover
+    import logging
+
+    def get_logger(name: str):
+        logging.basicConfig(
+            level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+        )
+        return logging.getLogger(name)
+
+
+log = get_logger("alerts_rate_limit")
+
+
+def _int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)).strip())
+    except Exception:
+        return default
+
+
+_WINDOW = max(1, _int("ALERTS_RATE_WINDOW_SECS", 60))
+_MAX = max(1, _int("ALERTS_RATE_MAX", 4))
+
+
+class _RateLimiter:
+    def __init__(self, window_secs: int, max_hits: int):
+        self.window = window_secs
+        self.max_hits = max_hits
+        self._buckets: Dict[str, Deque[float]] = {}
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        dq = self._buckets.setdefault(key, deque())
+        # purge old
+        while dq and (now - dq[0] > self.window):
+            dq.popleft()
+        if len(dq) >= self.max_hits:
+            return False
+        dq.append(now)
+        return True
+
+
+_RL = _RateLimiter(_WINDOW, _MAX)
+
+
+def limiter_key_from_payload(payload: dict) -> str:
+    # Prefer ticker; otherwise fold to a hashed-ish stable string via title/url presence
+    tkr = str(payload.get("ticker") or "").strip().upper()
+    if tkr:
+        return f"ticker:{tkr}"
+    title = str(payload.get("title") or "").strip()
+    if title:
+        return f"title:{title[:48]}"
+    link = str(payload.get("canonical_link") or payload.get("url") or "").strip()
+    if link:
+        return f"link:{link[:48]}"
+    return "misc:default"
+
+
+def limiter_allow(key: str) -> bool:
+    ok = _RL.allow(key)
+    if not ok:
+        log.info(
+            "rate_limit_triggered", extra={"key": key, "window": _WINDOW, "max": _MAX}
+        )
+    return ok

--- a/src/catalyst_bot/seen_store.py
+++ b/src/catalyst_bot/seen_store.py
@@ -1,0 +1,126 @@
+"""
+Seen Store v1 (SQLite TTL)
+
+Purpose
+-------
+Persist IDs we've alerted on so restarts do not re-alert the same item.
+
+Design
+------
+- Simple SQLite with a single table: seen(id TEXT PRIMARY KEY, ts INTEGER).
+- TTL cleanup on init and periodically when `purge_expired()` is called.
+- All ops are best-effort; failures should never crash the caller.
+
+Env
+---
+FEATURE_PERSIST_SEEN   (default: "true")
+SEEN_DB_PATH           (default: "data/seen_ids.sqlite")
+SEEN_TTL_DAYS          (default: "7")
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+try:
+    from catalyst_bot.logging_utils import get_logger  # type: ignore
+except Exception:  # pragma: no cover
+    import logging
+
+    def get_logger(name: str):
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        )
+        return logging.getLogger(name)
+
+
+log = get_logger("seen_store")
+
+
+def _env_flag(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class SeenStoreConfig:
+    path: Path
+    ttl_days: int
+
+
+class SeenStore:
+    def __init__(self, config: Optional[SeenStoreConfig] = None):
+        if config is None:
+            path = Path(os.getenv("SEEN_DB_PATH", "data/seen_ids.sqlite"))
+            ttl = int(os.getenv("SEEN_TTL_DAYS", "7"))
+            config = SeenStoreConfig(path=path, ttl_days=ttl)
+
+        self.cfg = config
+        self.cfg.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.cfg.path), check_same_thread=False)
+        self._ensure_schema()
+        self.purge_expired()
+
+    def _ensure_schema(self) -> None:
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS seen (
+                id TEXT PRIMARY KEY,
+                ts INTEGER NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def purge_expired(self) -> None:
+        ttl_secs = self.cfg.ttl_days * 86400
+        cutoff = int(time.time()) - ttl_secs
+        try:
+            cur = self._conn.cursor()
+            cur.execute("DELETE FROM seen WHERE ts < ?", (cutoff,))
+            self._conn.commit()
+        except Exception as e:  # pragma: no cover - non-fatal
+            log.warning("purge_expired_failed", extra={"error": str(e)})
+
+    def is_seen(self, item_id: str) -> bool:
+        try:
+            cur = self._conn.cursor()
+            cur.execute("SELECT 1 FROM seen WHERE id = ? LIMIT 1", (item_id,))
+            row = cur.fetchone()
+            return row is not None
+        except Exception as e:  # pragma: no cover - non-fatal
+            log.warning("is_seen_failed", extra={"error": str(e)})
+            return False
+
+    def mark_seen(self, item_id: str, ts: Optional[int] = None) -> None:
+        ts = int(time.time()) if ts is None else int(ts)
+        try:
+            cur = self._conn.cursor()
+            cur.execute(
+                "INSERT OR REPLACE INTO seen(id, ts) VALUES(?, ?)",
+                (item_id, ts),
+            )
+            self._conn.commit()
+        except Exception as e:  # pragma: no cover - non-fatal
+            log.warning("mark_seen_failed", extra={"error": str(e)})
+
+
+def should_filter(item_id: str, store: Optional[SeenStore] = None) -> bool:
+    """
+    Convenience helper: returns True if the item *should be filtered* (already seen),
+    respecting FEATURE_PERSIST_SEEN.
+    """
+    if not _env_flag("FEATURE_PERSIST_SEEN", "true"):
+        return False
+    if store is None:
+        store = SeenStore()
+    if store.is_seen(item_id):
+        return True
+    store.mark_seen(item_id)
+    return False

--- a/src/catalyst_bot/ticker_resolver.py
+++ b/src/catalyst_bot/ticker_resolver.py
@@ -1,0 +1,184 @@
+"""
+Ticker Resolver v1
+
+Goal
+----
+Best-effort ticker extraction with two stages:
+1) Title pattern matching (no network).
+2) Optional HTML page scrape (network, short timeout), gated by FEATURE_TICKER_RESOLVER_HTML.
+
+Design
+------
+- No required changes to existing code. Provide `resolve_from_source(...)` that can be
+  called as a fallback from feeds.extract_ticker(title) when it returns None.
+- Reads env flags directly to avoid churn in settings.py today.
+
+Env Flags
+---------
+FEATURE_TICKER_RESOLVER            (default: "true")
+FEATURE_TICKER_RESOLVER_HTML       (default: "false")
+TICKER_RESOLVER_HTML_TIMEOUT_SEC   (default: "3")
+TICKER_RESOLVER_USER_AGENT         (default: custom UA)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    # If the project has a structured logger, prefer it.
+    from catalyst_bot.logging_utils import get_logger  # type: ignore
+except Exception:  # pragma: no cover - fallback logger
+    import logging
+
+    def get_logger(name: str):
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        )
+        return logging.getLogger(name)
+
+
+log = get_logger("ticker_resolver")
+
+# Compile once; support common PR wire headline patterns.
+# Examples:
+#  - "Acme Corp (NASDAQ: ABC) announces..."
+#  - "Something something — NYSE: XYZ"
+#  - "Company Name (OTC: ABCD)"
+#  - "Company (Nasdaq: ABC)"
+#  - "Company [NYSE American: XYZ]"
+_EXCH_LABEL = r"(NASDAQ|Nasdaq|NYSE|NYSE\s+American|OTC|OTCQB|OTCQX|CSE|TSX|AMEX)"
+_TICKER_CORE = r"[A-Z]{1,5}(?:\.[A-Z])?"  # allow A, ABCD, BRK.B
+
+# Case-insensitive patterns so "wIdg" matches and is normalized to "WIDG".
+_FLAGS = re.IGNORECASE
+TITLE_PATTERNS = [
+    re.compile(rf"\(\s*{_EXCH_LABEL}\s*:\s*({_TICKER_CORE})\s*\)", _FLAGS),
+    re.compile(rf"{_EXCH_LABEL}\s*:\s*({_TICKER_CORE})", _FLAGS),
+    re.compile(rf"\[\s*{_EXCH_LABEL}\s*:\s*({_TICKER_CORE})\s*\]", _FLAGS),
+]
+
+# Very loose symbol guard for fallbacks.
+_SYMBOL_RE = re.compile(rf"\b({_TICKER_CORE})\b", _FLAGS)
+
+DEFAULT_UA = (
+    "CatalystBot/1.0 (+https://github.com/Amenzel91/catalyst-bot) "
+    "Python-requests/RESOLVER"
+)
+
+
+def _env_flag(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class ResolveResult:
+    ticker: Optional[str]
+    method: str  # "title", "html", or "none"
+
+
+def _try_from_title(title: str) -> Optional[str]:
+    if not title:
+        return None
+    for pat in TITLE_PATTERNS:
+        m = pat.search(title)
+        if m:
+            sym = m.group(2 if m.lastindex and m.lastindex >= 2 else 1)
+            return sym.upper()
+    # Extremely conservative loose fallback: single-hit token that looks
+    # like a symbol.
+    # Avoid returning common words; require it to be in parentheses or
+    # brackets context if ambiguous.
+    paren_ctx = re.findall(r"\(([^)]{1,40})\)", title) + re.findall(
+        r"\[([^\]]{1,40})\]", title
+    )
+    for ctx in paren_ctx:
+        m = _SYMBOL_RE.search(ctx)
+        if m:
+            return m.group(1).upper()
+    return None
+
+
+def _try_from_html(url: str) -> Optional[str]:
+    """Fetch page and attempt to find a labeled ticker. Short timeouts, safe failure."""
+    try:
+        import requests  # lazy import so tests without requests can still run
+    except Exception:
+        return None
+
+    if not url or url.startswith("about:"):
+        return None
+
+    timeout = float(os.getenv("TICKER_RESOLVER_HTML_TIMEOUT_SEC", "3"))
+    ua = os.getenv("TICKER_RESOLVER_USER_AGENT", DEFAULT_UA)
+    headers = {"User-Agent": ua}
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=timeout)
+        if resp.status_code != 200 or not resp.text:
+            return None
+        html = resp.text
+    except Exception:
+        return None
+
+    # Look for explicit "NASDAQ: ABC" etc first
+    for pat in TITLE_PATTERNS:
+        m = pat.search(html)
+        if m:
+            sym = m.group(2 if m.lastindex and m.lastindex >= 2 else 1)
+            return sym.upper()
+
+    # Then look for likely symbol near exchange words
+    exch_words = [
+        "Nasdaq",
+        "NASDAQ",
+        "NYSE",
+        "NYSE American",
+        "OTC",
+        "OTCQX",
+        "OTCQB",
+        "CSE",
+        "TSX",
+        "AMEX",
+    ]
+    for w in exch_words:
+        idx = html.find(w)
+        if idx != -1:
+            window = html[max(0, idx - 50) : idx + 50]
+            m = _SYMBOL_RE.search(window)
+            if m:
+                return m.group(1).upper()
+
+    return None
+
+
+def resolve_from_source(
+    title: str,
+    link: Optional[str],
+    source_host: Optional[str],
+) -> ResolveResult:
+    """
+    Public entrypoint used by feeds.py fallback.
+
+    Returns:
+        ResolveResult(ticker=<str|None>, method="title"|"html"|"none")
+    """
+    if not _env_flag("FEATURE_TICKER_RESOLVER", "true"):
+        return ResolveResult(ticker=None, method="none")
+
+    # Stage 1: title
+    t = _try_from_title(title or "")
+    if t:
+        return ResolveResult(ticker=t, method="title")
+
+    # Stage 2: optional HTML probe (opt-in)
+    if _env_flag("FEATURE_TICKER_RESOLVER_HTML", "false") and link:
+        h = _try_from_html(link)
+        if h:
+            return ResolveResult(ticker=h, method="html")
+
+    return ResolveResult(ticker=None, method="none")

--- a/src/catalyst_bot/ticker_sanity.py
+++ b/src/catalyst_bot/ticker_sanity.py
@@ -1,0 +1,54 @@
+"""
+Ticker Sanity Rules
+
+Purpose
+-------
+Downstream classifier noise in logs was caused by junk tickers like "FILER" or
+country codes (e.g., "AT", "AU") bubbling up from certain sources.
+This module applies lightweight, US-listed oriented validation.
+
+Behavior
+--------
+- Uppercases and strips surrounding whitespace.
+- Rejects strings that aren't 1-5 alphas (allow a single '.' for classes like BRK.B).
+- Rejects known junk tokens: "FILER".
+- Rejects a small set of problematic 2-letter country codes seen in feeds: {"AT", "AU"}.
+- Returns `None` on rejection; otherwise returns cleaned ticker.
+
+Flags
+-----
+The site hook controls whether sanitation is applied (HOOK_TICKER_SANITY=true).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# allow A, AA, AAPL, BRK.B (one optional class dot)
+_VALID_RE = re.compile(r"^[A-Z]{1,5}(\.[A-Z])?$")
+
+# minimal stoplist based on observed logs (keep conservative)
+_STOP = {"FILER"}
+
+# small set of mis-extracted country codes we saw
+_BAD_2LETTER = {"AT", "AU"}
+
+
+def sanitize_ticker(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip().upper()
+    if not s:
+        return None
+
+    if s in _STOP:
+        return None
+
+    if len(s) == 2 and s in _BAD_2LETTER:
+        return None
+
+    if not _VALID_RE.match(s):
+        return None
+
+    return s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+# Narrow deprecation filter for tests only.
+# Keeps application logging intact while preventing noisy utcnow warnings during pytest runs.
+import warnings
+
+
+def pytest_configure(config):
+    # Suppress only the well-known Python 3.12+ deprecation for datetime.utcnow() in tests.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"datetime\.datetime\.utcnow\(\) is deprecated.*",
+        category=DeprecationWarning,
+    )

--- a/tests/test_seen_store.py
+++ b/tests/test_seen_store.py
@@ -1,0 +1,33 @@
+import time
+from pathlib import Path
+
+from catalyst_bot.seen_store import SeenStore, SeenStoreConfig, should_filter
+
+
+def test_seen_store_mark_and_query_roundtrip(tmp_path: Path):
+    db_path = tmp_path / "seen.sqlite"
+    store = SeenStore(SeenStoreConfig(path=db_path, ttl_days=7))
+    assert store.is_seen("id-1") is False
+    store.mark_seen("id-1", ts=int(time.time()))
+    assert store.is_seen("id-1") is True
+
+
+def test_should_filter_with_env_flag_off(monkeypatch, tmp_path: Path):
+    # Force off
+    monkeypatch.setenv("FEATURE_PERSIST_SEEN", "false")
+    db_path = tmp_path / "seen.sqlite"
+    store = SeenStore(SeenStoreConfig(path=db_path, ttl_days=7))
+    # First time, should not filter; and not persist because feature is off
+    assert should_filter("abc", store) is False
+    # Again false — because feature is off (we aren't checking DB)
+    assert should_filter("abc", store) is False
+
+
+def test_ttl_cleanup(tmp_path: Path):
+    db_path = tmp_path / "seen.sqlite"
+    store = SeenStore(SeenStoreConfig(path=db_path, ttl_days=0))
+    # Insert seen with old timestamp
+    old_ts = int(time.time()) - 999999
+    store.mark_seen("dead", ts=old_ts)
+    store.purge_expired()
+    assert store.is_seen("dead") is False

--- a/tests/test_ticker_resolver.py
+++ b/tests/test_ticker_resolver.py
@@ -1,0 +1,20 @@
+from catalyst_bot.ticker_resolver import _try_from_title, resolve_from_source
+
+
+def test_try_from_title_basic_patterns():
+    assert _try_from_title("Acme Corp (NASDAQ: ABC) announces...") == "ABC"
+    assert _try_from_title("Example — NYSE: XYZ completes merger") == "XYZ"
+    assert _try_from_title("Company [OTC: ABCD] files 8-K") == "ABCD"
+    assert _try_from_title("WidgetCo (Nasdaq: wIdg) to present") == "WIDG"
+
+
+def test_resolve_from_source_title_win():
+    r = resolve_from_source("MegaCo (NYSE American: MEGA) update", None, None)
+    assert r.ticker == "MEGA"
+    assert r.method == "title"
+
+
+def test_resolve_from_source_none():
+    r = resolve_from_source("No symbol here", None, None)
+    assert r.ticker is None
+    assert r.method in {"none", "title"}  # title path returns None => "none"


### PR DESCRIPTION
Introduces alert_guard for stable alert IDs, alerts_rate_limit for Discord rate limiting, seen_store for persistent alert deduplication, ticker_resolver for best-effort ticker extraction, and ticker_sanity for ticker validation. Hooks are integrated via sitecustomize.py to patch core behaviors without modifying existing modules. Includes tests for seen_store and ticker_resolver, and updates runner.py to improve ticker handling and error resilience.